### PR TITLE
Add librarian dashboard, services, and APIs

### DIFF
--- a/app/api/librarian/books/route.ts
+++ b/app/api/librarian/books/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server"
+
+import { createLibraryBook, getLibraryState } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const { books } = await getLibraryState()
+    return NextResponse.json({ books })
+  } catch (error) {
+    console.error("Failed to load library books", error)
+    return NextResponse.json({ error: "Failed to load library books." }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json()
+    const { title, author, category, copies, isbn, addedBy } = payload ?? {}
+
+    if (!title || typeof title !== "string") {
+      return NextResponse.json({ error: "title is required." }, { status: 400 })
+    }
+    if (!author || typeof author !== "string") {
+      return NextResponse.json({ error: "author is required." }, { status: 400 })
+    }
+    if (!category || typeof category !== "string") {
+      return NextResponse.json({ error: "category is required." }, { status: 400 })
+    }
+
+    const numericCopies = Number.parseInt(String(copies ?? ""), 10)
+    const safeCopies = Number.isFinite(numericCopies) && numericCopies > 0 ? numericCopies : 1
+
+    const book = await createLibraryBook({
+      title: title.trim(),
+      author: author.trim(),
+      category: category.trim(),
+      copies: safeCopies,
+      isbn: typeof isbn === "string" && isbn.trim() ? isbn.trim() : undefined,
+      addedBy: typeof addedBy === "string" && addedBy.trim() ? addedBy.trim() : undefined,
+    })
+
+    return NextResponse.json({ book }, { status: 201 })
+  } catch (error) {
+    console.error("Failed to create library book", error)
+    return NextResponse.json({ error: "Failed to add book." }, { status: 500 })
+  }
+}

--- a/app/api/librarian/borrowed/return/route.ts
+++ b/app/api/librarian/borrowed/return/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server"
+
+import { markBorrowedBookReturned } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json()
+    const { borrowId } = payload ?? {}
+
+    if (!borrowId || typeof borrowId !== "string") {
+      return NextResponse.json({ error: "borrowId is required." }, { status: 400 })
+    }
+
+    const record = await markBorrowedBookReturned(borrowId)
+    if (!record) {
+      return NextResponse.json({ error: "Borrow record not found." }, { status: 404 })
+    }
+
+    return NextResponse.json({ record })
+  } catch (error) {
+    console.error("Failed to mark book as returned", error)
+    return NextResponse.json({ error: "Failed to mark book as returned." }, { status: 500 })
+  }
+}

--- a/app/api/librarian/borrowed/route.ts
+++ b/app/api/librarian/borrowed/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+import { getLibraryState } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const { borrowed } = await getLibraryState()
+    return NextResponse.json({ borrowed })
+  } catch (error) {
+    console.error("Failed to load borrowed books", error)
+    return NextResponse.json({ error: "Failed to load borrowed books." }, { status: 500 })
+  }
+}

--- a/app/api/librarian/overview/route.ts
+++ b/app/api/librarian/overview/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server"
+
+import { buildLibrarySnapshot, getLibraryState } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const state = await getLibraryState()
+    const snapshot = buildLibrarySnapshot(state)
+    return NextResponse.json({ snapshot })
+  } catch (error) {
+    console.error("Failed to load library snapshot", error)
+    return NextResponse.json({ error: "Failed to load library overview." }, { status: 500 })
+  }
+}

--- a/app/api/librarian/requests/[id]/route.ts
+++ b/app/api/librarian/requests/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+import { updateBookRequestStatus } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function PATCH(request: Request, context: { params: { id: string } }) {
+  try {
+    const { id } = context.params
+    const payload = await request.json()
+    const { status, actorId } = payload ?? {}
+
+    if (status !== "approved" && status !== "rejected") {
+      return NextResponse.json({ error: "status must be 'approved' or 'rejected'." }, { status: 400 })
+    }
+
+    const actor = typeof actorId === "string" && actorId.trim() ? actorId.trim() : "usr-librarian-1"
+    const updated = await updateBookRequestStatus(id, status, actor)
+
+    return NextResponse.json({ request: updated })
+  } catch (error) {
+    console.error("Failed to update book request", error)
+    return NextResponse.json({ error: "Failed to update request." }, { status: 500 })
+  }
+}

--- a/app/api/librarian/requests/route.ts
+++ b/app/api/librarian/requests/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server"
+
+import { getLibraryState } from "@/lib/librarian-service"
+
+export const dynamic = "force-dynamic"
+
+export async function GET() {
+  try {
+    const { requests } = await getLibraryState()
+    return NextResponse.json({ requests })
+  } catch (error) {
+    console.error("Failed to load book requests", error)
+    return NextResponse.json({ error: "Failed to load requests." }, { status: 500 })
+  }
+}

--- a/app/librarian/page.tsx
+++ b/app/librarian/page.tsx
@@ -1,0 +1,82 @@
+import { formatDistanceToNowStrict } from "date-fns"
+
+import { LibrarianDashboard } from "@/components/librarian-dashboard"
+import { ActivityFeed } from "@/components/activity-feed"
+import { NotificationCenter } from "@/components/notification-center"
+import { SystemHealthMonitor } from "@/components/system-health-monitor"
+import {
+  buildLibrarySnapshot,
+  getLibrarianProfile,
+  getLibraryState,
+} from "@/lib/librarian-service"
+
+export const metadata = {
+  title: "Librarian Control Centre",
+}
+
+function formatRelative(value: string) {
+  try {
+    return formatDistanceToNowStrict(new Date(value), { addSuffix: true })
+  } catch (error) {
+    console.error("Failed to format relative time", error)
+    return "recently"
+  }
+}
+
+export default async function LibrarianPage() {
+  const [profile, state] = await Promise.all([getLibrarianProfile(), getLibraryState()])
+  const snapshot = buildLibrarySnapshot(state)
+
+  return (
+    <main className="space-y-10">
+      <section className="rounded-3xl border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">Library workspace</p>
+            <h1 className="text-2xl font-semibold leading-tight">
+              Welcome back, {profile.name.split(" ")[0]}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Office: {profile.officeLocation} • Extension: {profile.extension}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Last login {formatRelative(profile.lastLogin)} • Contact: {profile.phone}
+            </p>
+          </div>
+
+          <dl className="grid gap-4 text-sm sm:grid-cols-2 lg:max-w-xl">
+            <div className="rounded-2xl border bg-muted/40 p-4">
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Titles catalogued</dt>
+              <dd className="text-base font-semibold text-foreground">{snapshot.totalTitles}</dd>
+            </div>
+            <div className="rounded-2xl border bg-muted/40 p-4">
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Copies in circulation</dt>
+              <dd className="text-base font-semibold text-foreground">{snapshot.totalCopies}</dd>
+            </div>
+            <div className="rounded-2xl border bg-muted/40 p-4">
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Active loans</dt>
+              <dd className="text-base font-semibold text-foreground">{snapshot.borrowedActive}</dd>
+            </div>
+            <div className="rounded-2xl border bg-muted/40 p-4">
+              <dt className="text-xs uppercase tracking-wide text-muted-foreground">Pending requests</dt>
+              <dd className="text-base font-semibold text-foreground">{snapshot.pendingRequests}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <LibrarianDashboard
+        librarian={profile}
+        initialData={{ books: state.books, borrowed: state.borrowed, requests: state.requests }}
+      />
+
+      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <ActivityFeed userRole="librarian" />
+        <div className="space-y-8">
+          <NotificationCenter userRole="librarian" />
+          <SystemHealthMonitor />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/components/activity-feed.tsx
+++ b/components/activity-feed.tsx
@@ -11,6 +11,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 const ENDPOINTS: Record<string, string> = {
   "super-admin": "/api/super-admin/activity",
   admin: "/api/admin/activity",
+  librarian: "/api/super-admin/activity",
 };
 
 function resolveEndpoint(role: string | undefined) {

--- a/components/librarian-dashboard.tsx
+++ b/components/librarian-dashboard.tsx
@@ -1,13 +1,32 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import { useEffect, useRef, useState } from "react"
+import { AlertTriangle, Archive, BookOpen, Plus, Search, Users } from "lucide-react"
+
 import { Badge } from "@/components/ui/badge"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
-import { BookOpen, Search, Plus, Users, Calendar, AlertTriangle } from "lucide-react"
-import { DatabaseManager } from "@/lib/database-manager"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  createLibraryBook,
+  enrichBookRequests,
+  enrichBorrowedBooks,
+  enrichLibraryBooks,
+  getLibraryState,
+  markBorrowedBookReturned,
+  updateBookRequestStatus,
+  type BookRequestRecord,
+  type BorrowedBookRecord,
+  type LibraryBookRecord,
+} from "@/lib/librarian-service"
+import {
+  DatabaseManager,
+  type Book,
+  type BookRequest,
+  type BorrowedBook,
+  type Student,
+} from "@/lib/database-manager"
 
 interface LibrarianDashboardProps {
   librarian: {
@@ -15,66 +34,131 @@ interface LibrarianDashboardProps {
     name: string
     email: string
   }
+  initialData?: {
+    books: LibraryBookRecord[]
+    borrowed: BorrowedBookRecord[]
+    requests: BookRequestRecord[]
+  }
 }
 
-export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
+export function LibrarianDashboard({ librarian, initialData }: LibrarianDashboardProps) {
+  const managerRef = useRef(DatabaseManager.getInstance())
   const [selectedTab, setSelectedTab] = useState("overview")
   const [searchTerm, setSearchTerm] = useState("")
-  const [books, setBooks] = useState<any[]>([])
-  const [borrowedBooks, setBorrowedBooks] = useState<any[]>([])
-  const [requests, setRequests] = useState<any[]>([])
-  const [loading, setLoading] = useState(true)
+  const [books, setBooks] = useState<LibraryBookRecord[]>(() => initialData?.books ?? [])
+  const [borrowedBooks, setBorrowedBooks] = useState<BorrowedBookRecord[]>(() => initialData?.borrowed ?? [])
+  const [requests, setRequests] = useState<BookRequestRecord[]>(() => initialData?.requests ?? [])
+  const [loading, setLoading] = useState(() => !initialData)
 
-  const dbManager = DatabaseManager.getInstance()
+  const rawBooksRef = useRef<Book[]>([])
+  const rawBorrowedRef = useRef<BorrowedBook[]>([])
+  const rawRequestsRef = useRef<BookRequest[]>([])
+  const studentsRef = useRef<Student[]>([])
 
   useEffect(() => {
+    let active = true
+
+    async function loadLibraryData() {
+      try {
+        if (!initialData) {
+          setLoading(true)
+        }
+
+        const state = await getLibraryState()
+        if (!active) return
+
+        rawBooksRef.current = state.context.books
+        rawBorrowedRef.current = state.context.borrowed
+        rawRequestsRef.current = state.context.requests
+        studentsRef.current = state.context.students
+
+        setBooks(state.books)
+        setBorrowedBooks(state.borrowed)
+        setRequests(state.requests)
+      } catch (error) {
+        console.error("Error loading library data:", error)
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
     loadLibraryData()
 
-    const unsubscribeBooks = dbManager.subscribe("books", (data) => {
-      setBooks(data || [])
+    const unsubscribeBooks = managerRef.current.subscribe("books", (data) => {
+      rawBooksRef.current = Array.isArray(data) ? (data as Book[]) : []
+      setBooks(enrichLibraryBooks(rawBooksRef.current))
+      setBorrowedBooks(
+        enrichBorrowedBooks(rawBorrowedRef.current, {
+          books: rawBooksRef.current,
+          students: studentsRef.current,
+        }),
+      )
+      setRequests(
+        enrichBookRequests(rawRequestsRef.current, {
+          books: rawBooksRef.current,
+          students: studentsRef.current,
+        }),
+      )
     })
 
-    const unsubscribeBorrowed = dbManager.subscribe("borrowedBooks", (data) => {
-      setBorrowedBooks(data || [])
+    const unsubscribeBorrowed = managerRef.current.subscribe("borrowedBooks", (data) => {
+      rawBorrowedRef.current = Array.isArray(data) ? (data as BorrowedBook[]) : []
+      setBorrowedBooks(
+        enrichBorrowedBooks(rawBorrowedRef.current, {
+          books: rawBooksRef.current,
+          students: studentsRef.current,
+        }),
+      )
     })
 
-    const unsubscribeRequests = dbManager.subscribe("bookRequests", (data) => {
-      setRequests(data || [])
+    const unsubscribeRequests = managerRef.current.subscribe("bookRequests", (data) => {
+      rawRequestsRef.current = Array.isArray(data) ? (data as BookRequest[]) : []
+      setRequests(
+        enrichBookRequests(rawRequestsRef.current, {
+          books: rawBooksRef.current,
+          students: studentsRef.current,
+        }),
+      )
     })
 
     return () => {
+      active = false
       unsubscribeBooks()
       unsubscribeBorrowed()
       unsubscribeRequests()
     }
-  }, [])
+  }, [initialData])
 
-  const loadLibraryData = async () => {
+  const totalCopies = books.reduce((sum, book) => sum + book.copies, 0)
+  const availableCopies = books.reduce((sum, book) => sum + book.available, 0)
+  const activeLoans = borrowedBooks.filter((record) => record.status === "active")
+  const pendingRequests = requests.filter((request) => request.status === "pending")
+  const overdueLoans = activeLoans.filter((record) => record.isOverdue)
+
+  const handleAddBook = async (bookData: {
+    title: string
+    author: string
+    isbn?: string | null
+    copies: number
+    category: string
+  }) => {
     try {
-      setLoading(true)
-      const booksData = await dbManager.getBooks()
-      const borrowedData = await dbManager.getBorrowedBooks()
-      const requestsData = await dbManager.getBookRequests()
+      if (!bookData.title || !bookData.author || !bookData.category) {
+        return
+      }
 
-      setBooks(booksData)
-      setBorrowedBooks(borrowedData)
-      setRequests(requestsData)
-    } catch (error) {
-      console.error("Error loading library data:", error)
-    } finally {
-      setLoading(false)
-    }
-  }
+      const copies = Number.isFinite(bookData.copies) ? Math.max(1, Math.floor(bookData.copies)) : 1
 
-  const handleAddBook = async (bookData: any) => {
-    try {
-      await dbManager.addBook({
-        ...bookData,
-        id: Date.now().toString(),
+      await createLibraryBook({
+        title: bookData.title.trim(),
+        author: bookData.author.trim(),
+        category: bookData.category.trim(),
+        copies,
+        isbn: bookData.isbn?.trim() || undefined,
         addedBy: librarian.id,
-        addedDate: new Date().toISOString(),
       })
-      // Data will update automatically via real-time listener
     } catch (error) {
       console.error("Error adding book:", error)
     }
@@ -82,10 +166,7 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
 
   const handleApproveRequest = async (requestId: string) => {
     try {
-      await dbManager.updateBookRequest(requestId, {
-        status: "approved",
-        approvedBy: librarian.id,
-      })
+      await updateBookRequestStatus(requestId, "approved", librarian.id)
     } catch (error) {
       console.error("Error approving request:", error)
     }
@@ -93,10 +174,7 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
 
   const handleRejectRequest = async (requestId: string) => {
     try {
-      await dbManager.updateBookRequest(requestId, {
-        status: "rejected",
-        rejectedBy: librarian.id,
-      })
+      await updateBookRequestStatus(requestId, "rejected", librarian.id)
     } catch (error) {
       console.error("Error rejecting request:", error)
     }
@@ -104,24 +182,17 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
 
   const handleReturnBook = async (borrowId: string) => {
     try {
-      await dbManager.returnBook(borrowId, {
-        returnedAt: new Date().toISOString(),
-      })
+      await markBorrowedBookReturned(borrowId)
     } catch (error) {
       console.error("Error returning book:", error)
     }
   }
 
-  const overdueBooks = borrowedBooks.filter((book) => {
-    const dueDate = new Date(book.dueDate)
-    return dueDate < new Date() && book.status === "active"
-  })
-
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex h-64 items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#2d682d] mx-auto"></div>
+          <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-[#2d682d]"></div>
           <p className="mt-2 text-gray-600">Loading library data...</p>
         </div>
       </div>
@@ -130,61 +201,54 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="bg-gradient-to-r from-[#2d682d] to-[#b29032] text-white p-6 rounded-lg">
+      <div className="rounded-lg bg-gradient-to-r from-[#2d682d] to-[#b29032] p-6 text-white">
         <h1 className="text-2xl font-bold">Welcome, {librarian.name}</h1>
         <p className="text-green-100">Library Management - VEA 2025</p>
       </div>
 
-      {/* Quick Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center space-x-2">
-              <BookOpen className="h-8 w-8 text-[#2d682d]" />
-              <div>
-                <p className="text-2xl font-bold text-[#2d682d]">{books.length}</p>
-                <p className="text-sm text-gray-600">Total Books</p>
-              </div>
+          <CardContent className="flex items-center space-x-2 p-4">
+            <BookOpen className="h-8 w-8 text-[#2d682d]" />
+            <div>
+              <p className="text-2xl font-bold text-[#2d682d]">{books.length}</p>
+              <p className="text-sm text-gray-600">Titles Catalogued</p>
             </div>
           </CardContent>
         </Card>
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center space-x-2">
-              <Users className="h-8 w-8 text-[#b29032]" />
-              <div>
-                <p className="text-2xl font-bold text-[#b29032]">{borrowedBooks.length}</p>
-                <p className="text-sm text-gray-600">Borrowed</p>
-              </div>
+          <CardContent className="flex items-center space-x-2 p-4">
+            <Archive className="h-8 w-8 text-[#b29032]" />
+            <div>
+              <p className="text-2xl font-bold text-[#b29032]">{availableCopies}</p>
+              <p className="text-sm text-gray-600">Copies Available</p>
+              <p className="text-xs text-gray-500">{totalCopies} total copies</p>
             </div>
           </CardContent>
         </Card>
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center space-x-2">
-              <Calendar className="h-8 w-8 text-[#2d682d]" />
-              <div>
-                <p className="text-2xl font-bold text-[#2d682d]">{requests.length}</p>
-                <p className="text-sm text-gray-600">Requests</p>
-              </div>
+          <CardContent className="flex items-center space-x-2 p-4">
+            <Users className="h-8 w-8 text-[#2d682d]" />
+            <div>
+              <p className="text-2xl font-bold text-[#2d682d]">{activeLoans.length}</p>
+              <p className="text-sm text-gray-600">Active Loans</p>
+              <p className="text-xs text-gray-500">
+                Overdue: <span className={overdueLoans.length ? "text-red-500" : "text-gray-500"}>{overdueLoans.length}</span>
+              </p>
             </div>
           </CardContent>
         </Card>
         <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center space-x-2">
-              <AlertTriangle className="h-8 w-8 text-red-500" />
-              <div>
-                <p className="text-2xl font-bold text-red-500">{overdueBooks.length}</p>
-                <p className="text-sm text-gray-600">Overdue</p>
-              </div>
+          <CardContent className="flex items-center space-x-2 p-4">
+            <AlertTriangle className="h-8 w-8 text-red-500" />
+            <div>
+              <p className="text-2xl font-bold text-red-500">{pendingRequests.length}</p>
+              <p className="text-sm text-gray-600">Pending Requests</p>
             </div>
           </CardContent>
         </Card>
       </div>
 
-      {/* Main Content */}
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -194,40 +258,40 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
         </TabsList>
 
         <TabsContent value="overview" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             <Card>
               <CardHeader>
                 <CardTitle className="text-[#2d682d]">Recent Activity</CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="space-y-2">
-                  {borrowedBooks.slice(0, 3).map((book, index) => (
-                    <div key={index} className="p-2 bg-green-50 border-l-4 border-[#2d682d] rounded">
+                  {activeLoans.slice(0, 3).map((record) => (
+                    <div key={record.id} className="rounded border-l-4 border-[#2d682d] bg-green-50 p-2">
                       <p className="text-sm font-medium">Book Borrowed</p>
                       <p className="text-xs text-gray-600">
-                        {book.bookTitle} by {book.studentName}
+                        {record.bookTitle} by {record.studentName}
                       </p>
                     </div>
                   ))}
-                  {requests
-                    .filter((r) => r.status === "pending")
-                    .slice(0, 2)
-                    .map((request, index) => (
-                      <div key={index} className="p-2 bg-yellow-50 border-l-4 border-[#b29032] rounded">
-                        <p className="text-sm font-medium">New Request</p>
-                        <p className="text-xs text-gray-600">
-                          {request.bookTitle} by {request.studentName}
-                        </p>
-                      </div>
-                    ))}
-                  {overdueBooks.slice(0, 1).map((book, index) => (
-                    <div key={index} className="p-2 bg-red-50 border-l-4 border-red-500 rounded">
+                  {pendingRequests.slice(0, 2).map((request) => (
+                    <div key={request.id} className="rounded border-l-4 border-[#b29032] bg-yellow-50 p-2">
+                      <p className="text-sm font-medium">New Request</p>
+                      <p className="text-xs text-gray-600">
+                        {request.bookTitle} by {request.studentName}
+                      </p>
+                    </div>
+                  ))}
+                  {overdueLoans.slice(0, 1).map((record) => (
+                    <div key={record.id} className="rounded border-l-4 border-red-500 bg-red-50 p-2">
                       <p className="text-sm font-medium">Overdue Alert</p>
                       <p className="text-xs text-gray-600">
-                        {book.bookTitle} by {book.studentName}
+                        {record.bookTitle} by {record.studentName}
                       </p>
                     </div>
                   ))}
+                  {!activeLoans.length && !pendingRequests.length && !overdueLoans.length ? (
+                    <p className="text-sm text-gray-500">No recent activity.</p>
+                  ) : null}
                 </div>
               </CardContent>
             </Card>
@@ -238,15 +302,20 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
               </CardHeader>
               <CardContent>
                 <div className="space-y-2">
-                  {books.slice(0, 5).map((book) => (
-                    <div key={book.id} className="flex justify-between items-center p-2 bg-gray-50 rounded">
-                      <div>
-                        <p className="text-sm font-medium">{book.title}</p>
-                        <p className="text-xs text-gray-600">{book.author}</p>
+                  {books
+                    .slice()
+                    .sort((a, b) => b.borrowedCount - a.borrowedCount)
+                    .slice(0, 5)
+                    .map((book) => (
+                      <div key={book.id} className="flex items-center justify-between rounded bg-gray-50 p-2">
+                        <div>
+                          <p className="text-sm font-medium">{book.title}</p>
+                          <p className="text-xs text-gray-600">{book.author}</p>
+                        </div>
+                        <Badge variant="outline">{book.borrowedCount} borrowed</Badge>
                       </div>
-                      <Badge variant="outline">{(book.copies || 0) - (book.available || 0)} borrowed</Badge>
-                    </div>
-                  ))}
+                    ))}
+                  {!books.length ? <p className="text-sm text-gray-500">No books in catalogue.</p> : null}
                 </div>
               </CardContent>
             </Card>
@@ -259,78 +328,82 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
               <CardTitle className="text-[#2d682d]">Book Management</CardTitle>
               <CardDescription>Manage library books and inventory</CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <div className="flex space-x-2">
-                  <div className="relative flex-1">
-                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-500" />
-                    <Input
-                      placeholder="Search books..."
-                      value={searchTerm}
-                      onChange={(e) => setSearchTerm(e.target.value)}
-                      className="pl-8"
-                    />
-                  </div>
-                  <Button
-                    className="bg-[#b29032] hover:bg-[#b29032]/90"
-                    onClick={() => {
-                      const title = prompt("Enter book title:")
-                      const author = prompt("Enter author:")
-                      const isbn = prompt("Enter ISBN:")
-                      const copies = prompt("Enter number of copies:")
-                      const category = prompt("Enter category:")
-
-                      if (title && author && isbn && copies && category) {
-                        handleAddBook({
-                          title,
-                          author,
-                          isbn,
-                          copies: Number.parseInt(copies),
-                          available: Number.parseInt(copies),
-                          category,
-                        })
-                      }
-                    }}
-                  >
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add Book
-                  </Button>
+            <CardContent className="space-y-4">
+              <div className="flex space-x-2">
+                <div className="relative flex-1">
+                  <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-500" />
+                  <Input
+                    placeholder="Search books..."
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    className="pl-8"
+                  />
                 </div>
+                <Button
+                  className="bg-[#b29032] hover:bg-[#b29032]/90"
+                  onClick={async () => {
+                    const title = prompt("Enter book title:")?.trim()
+                    const author = prompt("Enter author:")?.trim()
+                    const isbn = prompt("Enter ISBN (optional):")?.trim()
+                    const copiesValue = prompt("Enter number of copies:")?.trim()
+                    const category = prompt("Enter category:")?.trim()
 
-                <div className="space-y-2">
-                  {books
-                    .filter(
-                      (book) =>
-                        book.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                        book.author?.toLowerCase().includes(searchTerm.toLowerCase()),
+                    const copies = copiesValue ? Number.parseInt(copiesValue, 10) : 1
+
+                    if (title && author && category) {
+                      await handleAddBook({
+                        title,
+                        author,
+                        isbn: isbn ?? undefined,
+                        copies,
+                        category,
+                      })
+                    }
+                  }}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  Add Book
+                </Button>
+              </div>
+
+              <div className="space-y-2">
+                {books
+                  .filter((book) => {
+                    const term = searchTerm.toLowerCase().trim()
+                    if (!term) return true
+                    return (
+                      book.title.toLowerCase().includes(term) ||
+                      book.author.toLowerCase().includes(term) ||
+                      (book.isbn?.toLowerCase().includes(term) ?? false)
                     )
-                    .map((book) => (
-                      <div key={book.id} className="flex justify-between items-center p-4 border rounded-lg">
-                        <div className="flex-1">
-                          <h3 className="font-medium">{book.title}</h3>
-                          <p className="text-sm text-gray-600">by {book.author}</p>
-                          <p className="text-xs text-gray-500">ISBN: {book.isbn}</p>
-                          <Badge variant="outline" className="mt-1">
-                            {book.category}
-                          </Badge>
-                        </div>
-                        <div className="text-center mr-4">
-                          <p className="text-sm font-medium">Available</p>
-                          <p className="text-lg font-bold text-[#2d682d]">
-                            {book.available || 0}/{book.copies || 0}
-                          </p>
-                        </div>
-                        <div className="space-x-2">
-                          <Button size="sm" variant="outline">
-                            Edit
-                          </Button>
-                          <Button size="sm" className="bg-[#2d682d] hover:bg-[#2d682d]/90">
-                            View Details
-                          </Button>
-                        </div>
+                  })
+                  .map((book) => (
+                    <div key={book.id} className="flex items-center justify-between rounded-lg border p-4">
+                      <div className="flex-1">
+                        <h3 className="font-medium">{book.title}</h3>
+                        <p className="text-sm text-gray-600">by {book.author}</p>
+                        {book.isbn ? <p className="text-xs text-gray-500">ISBN: {book.isbn}</p> : null}
+                        <Badge variant="outline" className="mt-1">
+                          {book.category}
+                        </Badge>
                       </div>
-                    ))}
-                </div>
+                      <div className="mr-4 text-center">
+                        <p className="text-sm font-medium">Availability</p>
+                        <p className="text-lg font-bold text-[#2d682d]">
+                          {book.available}/{book.copies}
+                        </p>
+                      </div>
+                      <div className="space-x-2">
+                        <Button size="sm" variant="outline">
+                          Edit
+                        </Button>
+                        <Button size="sm" className="bg-[#2d682d] hover:bg-[#2d682d]/90">
+                          View Details
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                {!books.length ? <p className="text-sm text-gray-500">No books found.</p> : null}
               </div>
             </CardContent>
           </Card>
@@ -342,44 +415,35 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
               <CardTitle className="text-[#2d682d]">Borrowed Books</CardTitle>
               <CardDescription>Track borrowed books and due dates</CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {borrowedBooks.map((record) => (
-                  <div key={record.id} className="flex justify-between items-center p-4 border rounded-lg">
-                    <div className="flex-1">
-                      <h3 className="font-medium">{record.bookTitle}</h3>
-                      <p className="text-sm text-gray-600">
-                        {record.studentName} ({record.studentClass})
-                      </p>
-                      <p className="text-xs text-gray-500">
-                        Borrowed: {record.borrowDate} | Due: {record.dueDate}
-                      </p>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Badge
-                        variant={
-                          new Date(record.dueDate) < new Date() && record.status === "active"
-                            ? "destructive"
-                            : "default"
-                        }
-                      >
-                        {new Date(record.dueDate) < new Date() && record.status === "active"
-                          ? "overdue"
-                          : record.status}
-                      </Badge>
-                      {record.status === "active" && (
-                        <Button
-                          size="sm"
-                          className="bg-[#2d682d] hover:bg-[#2d682d]/90"
-                          onClick={() => handleReturnBook(record.id)}
-                        >
-                          Return Book
-                        </Button>
-                      )}
-                    </div>
+            <CardContent className="space-y-4">
+              {borrowedBooks.map((record) => (
+                <div key={record.id} className="flex items-center justify-between rounded-lg border p-4">
+                  <div className="flex-1">
+                    <h3 className="font-medium">{record.bookTitle}</h3>
+                    <p className="text-sm text-gray-600">
+                      {record.studentName} ({record.studentClass})
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      Borrowed: {record.borrowDate} | Due: {record.dueDate}
+                    </p>
                   </div>
-                ))}
-              </div>
+                  <div className="flex items-center space-x-2">
+                    <Badge variant={record.isOverdue ? "destructive" : "default"}>
+                      {record.isOverdue ? "overdue" : record.status}
+                    </Badge>
+                    {record.status === "active" && (
+                      <Button
+                        size="sm"
+                        className="bg-[#2d682d] hover:bg-[#2d682d]/90"
+                        onClick={() => handleReturnBook(record.id)}
+                      >
+                        Return Book
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {!borrowedBooks.length ? <p className="text-sm text-gray-500">No active loans.</p> : null}
             </CardContent>
           </Card>
         </TabsContent>
@@ -390,37 +454,36 @@ export function LibrarianDashboard({ librarian }: LibrarianDashboardProps) {
               <CardTitle className="text-[#2d682d]">Book Requests</CardTitle>
               <CardDescription>Manage student book requests</CardDescription>
             </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {requests.map((request) => (
-                  <div key={request.id} className="flex justify-between items-center p-4 border rounded-lg">
-                    <div className="flex-1">
-                      <h3 className="font-medium">{request.bookTitle}</h3>
-                      <p className="text-sm text-gray-600">
-                        {request.studentName} ({request.studentClass})
-                      </p>
-                      <p className="text-xs text-gray-500">Requested: {request.requestDate}</p>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Badge variant={request.status === "pending" ? "secondary" : "default"}>{request.status}</Badge>
-                      {request.status === "pending" && (
-                        <>
-                          <Button size="sm" variant="outline" onClick={() => handleRejectRequest(request.id)}>
-                            Reject
-                          </Button>
-                          <Button
-                            size="sm"
-                            className="bg-[#2d682d] hover:bg-[#2d682d]/90"
-                            onClick={() => handleApproveRequest(request.id)}
-                          >
-                            Approve
-                          </Button>
-                        </>
-                      )}
-                    </div>
+            <CardContent className="space-y-4">
+              {requests.map((request) => (
+                <div key={request.id} className="flex items-center justify-between rounded-lg border p-4">
+                  <div className="flex-1">
+                    <h3 className="font-medium">{request.bookTitle}</h3>
+                    <p className="text-sm text-gray-600">
+                      {request.studentName} ({request.studentClass})
+                    </p>
+                    <p className="text-xs text-gray-500">Requested: {request.requestDate}</p>
                   </div>
-                ))}
-              </div>
+                  <div className="flex items-center space-x-2">
+                    <Badge variant={request.status === "pending" ? "secondary" : "outline"}>{request.status}</Badge>
+                    {request.status === "pending" && (
+                      <>
+                        <Button size="sm" variant="outline" onClick={() => handleRejectRequest(request.id)}>
+                          Reject
+                        </Button>
+                        <Button
+                          size="sm"
+                          className="bg-[#2d682d] hover:bg-[#2d682d]/90"
+                          onClick={() => handleApproveRequest(request.id)}
+                        >
+                          Approve
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {!requests.length ? <p className="text-sm text-gray-500">No requests at the moment.</p> : null}
             </CardContent>
           </Card>
         </TabsContent>

--- a/components/notification-center.tsx
+++ b/components/notification-center.tsx
@@ -23,6 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 const ENDPOINTS: Record<string, string> = {
   "super-admin": "/api/super-admin/notifications",
   admin: "/api/admin/notifications",
+  librarian: "/api/admin/notifications",
 };
 const POLL_INTERVAL = 90_000;
 

--- a/lib/librarian-service.ts
+++ b/lib/librarian-service.ts
@@ -1,0 +1,281 @@
+import {
+  DatabaseManager,
+  type Book,
+  type BookRequest,
+  type BorrowedBook,
+  type Student,
+} from "./database-manager"
+
+export interface LibrarianProfile {
+  id: string
+  name: string
+  email: string
+  phone: string
+  extension: string
+  officeLocation: string
+  lastLogin: string
+  responsibilities: string[]
+}
+
+export interface LibraryBookRecord extends Book {
+  available: number
+  borrowedCount: number
+  availabilityRate: number
+}
+
+export interface BorrowedBookRecord extends BorrowedBook {
+  borrowDate: string
+  bookTitle: string
+  studentName: string
+  studentClass: string
+  daysUntilDue: number | null
+  isOverdue: boolean
+}
+
+export interface BookRequestRecord extends BookRequest {
+  bookTitle: string
+  studentName: string
+  studentClass: string
+  requestDate: string
+  isPending: boolean
+}
+
+export interface LibrarySnapshot {
+  totalTitles: number
+  totalCopies: number
+  availableCopies: number
+  borrowedActive: number
+  pendingRequests: number
+  overdueLoans: number
+}
+
+export interface LibraryState {
+  books: LibraryBookRecord[]
+  borrowed: BorrowedBookRecord[]
+  requests: BookRequestRecord[]
+  context: {
+    books: Book[]
+    borrowed: BorrowedBook[]
+    requests: BookRequest[]
+    students: Student[]
+  }
+}
+
+const db = DatabaseManager.getInstance()
+
+function safeDate(value: string | undefined) {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function titleFromBookId(bookId: string, books: Book[]) {
+  return books.find((book) => book.id === bookId)?.title ?? "Unknown Title"
+}
+
+function studentFromId(studentId: string, students: Student[]) {
+  return students.find((student) => student.id === studentId)
+}
+
+function formatClass(student: Student | undefined) {
+  if (!student) return "—"
+  return student.section ? `${student.class} (${student.section})` : student.class
+}
+
+function normaliseBorrowStatus(status: BorrowedBook["status"] | "borrowed") {
+  return status === "returned" ? "returned" : "active"
+}
+
+export function enrichLibraryBooks(books: Book[]): LibraryBookRecord[] {
+  return books.map((book) => {
+    const total = Number.isFinite(book.copies) ? Number(book.copies) : 0
+    const available = Math.max(0, Math.min(total, Number(book.availableCopies ?? 0)))
+    const borrowedCount = Math.max(0, total - available)
+    const availabilityRate = total > 0 ? Math.round((available / total) * 1000) / 10 : 0
+
+    return {
+      ...book,
+      copies: total,
+      availableCopies: available,
+      available,
+      borrowedCount,
+      availabilityRate,
+      status: book.status ?? (available > 0 ? "available" : "unavailable"),
+      tags: book.tags ? [...book.tags] : undefined,
+    }
+  })
+}
+
+export function enrichBorrowedBooks(
+  borrowed: BorrowedBook[],
+  deps: { books: Book[]; students: Student[] },
+): BorrowedBookRecord[] {
+  return borrowed.map((record) => {
+    const status = normaliseBorrowStatus(record.status)
+    const borrowDate = record.borrowedAt ?? (record as any).borrowDate ?? ""
+    const borrowDateValue = safeDate(borrowDate)
+    const dueDateValue = safeDate(record.dueDate)
+    const now = new Date()
+    let daysUntilDue: number | null = null
+    let isOverdue = false
+
+    if (dueDateValue) {
+      const diff = Math.floor((dueDateValue.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+      daysUntilDue = diff
+      isOverdue = diff < 0 && status === "active"
+    }
+
+    return {
+      ...record,
+      status,
+      borrowDate: borrowDateValue ? borrowDateValue.toISOString().slice(0, 10) : borrowDate,
+      bookTitle: titleFromBookId(record.bookId, deps.books),
+      studentName: studentFromId(record.studentId, deps.students)?.name ?? "Unknown Student",
+      studentClass: formatClass(studentFromId(record.studentId, deps.students)),
+      daysUntilDue,
+      isOverdue,
+    }
+  })
+}
+
+export function enrichBookRequests(
+  requests: BookRequest[],
+  deps: { books: Book[]; students: Student[] },
+): BookRequestRecord[] {
+  return requests.map((request) => {
+    const student = studentFromId(request.studentId, deps.students)
+    const requestedAt = request.requestedAt ?? (request as any).requestDate ?? ""
+    const requestDateValue = safeDate(requestedAt)
+
+    return {
+      ...request,
+      bookTitle: titleFromBookId(request.bookId, deps.books),
+      studentName: student?.name ?? "Unknown Student",
+      studentClass: formatClass(student),
+      requestDate: requestDateValue ? requestDateValue.toISOString().slice(0, 10) : requestedAt,
+      isPending: request.status === "pending",
+    }
+  })
+}
+
+export function buildLibrarySnapshot(
+  data: Pick<LibraryState, "books" | "borrowed" | "requests">,
+): LibrarySnapshot {
+  const totalCopies = data.books.reduce((sum, book) => sum + book.copies, 0)
+  const availableCopies = data.books.reduce((sum, book) => sum + book.available, 0)
+  const totalTitles = data.books.length
+  const borrowedActive = data.borrowed.filter((record) => record.status === "active").length
+  const overdueLoans = data.borrowed.filter((record) => record.isOverdue).length
+  const pendingRequests = data.requests.filter((request) => request.status === "pending").length
+
+  return {
+    totalTitles,
+    totalCopies,
+    availableCopies,
+    borrowedActive,
+    pendingRequests,
+    overdueLoans,
+  }
+}
+
+export async function getLibraryState(): Promise<LibraryState> {
+  const [books, borrowed, requests, students] = await Promise.all([
+    db.getBooks(),
+    db.getBorrowedBooks(),
+    db.getBookRequests(),
+    db.getStudents(),
+  ])
+
+  return {
+    books: enrichLibraryBooks(books),
+    borrowed: enrichBorrowedBooks(borrowed, { books, students }),
+    requests: enrichBookRequests(requests, { books, students }),
+    context: {
+      books,
+      borrowed,
+      requests,
+      students,
+    },
+  }
+}
+
+export async function listLibraryBooks() {
+  const { books } = await getLibraryState()
+  return books
+}
+
+export async function listBorrowedBooks() {
+  const { borrowed } = await getLibraryState()
+  return borrowed
+}
+
+export async function listBookRequests() {
+  const { requests } = await getLibraryState()
+  return requests
+}
+
+export async function getLibrarianProfile(): Promise<LibrarianProfile> {
+  return {
+    id: "usr-librarian-1",
+    name: "Chinonso Ibeh",
+    email: "librarian@vea.edu.ng",
+    phone: "+234 803 444 1188",
+    extension: "1402",
+    officeLocation: "Library Wing, Level 1",
+    lastLogin: new Date(Date.now() - 1000 * 60 * 28).toISOString(),
+    responsibilities: [
+      "Collection management",
+      "Student lending",
+      "Digital archive supervision",
+    ],
+  }
+}
+
+export async function getLibrarySnapshot(): Promise<LibrarySnapshot> {
+  const state = await getLibraryState()
+  return buildLibrarySnapshot(state)
+}
+
+export interface CreateLibraryBookInput {
+  title: string
+  author: string
+  category: string
+  copies: number
+  isbn?: string
+  addedBy?: string
+  tags?: string[]
+}
+
+export async function createLibraryBook(input: CreateLibraryBookInput) {
+  const payload = {
+    title: input.title,
+    author: input.author,
+    category: input.category,
+    copies: input.copies,
+    availableCopies: input.copies,
+    status: "available" as const,
+    isbn: input.isbn,
+    addedBy: input.addedBy,
+    addedDate: new Date().toISOString(),
+    tags: input.tags,
+  }
+
+  return db.addBook(payload)
+}
+
+export async function updateBookRequestStatus(
+  requestId: string,
+  status: "approved" | "rejected",
+  actorId: string,
+) {
+  const updates =
+    status === "approved"
+      ? { status, approvedBy: actorId }
+      : { status, rejectedBy: actorId }
+
+  return db.updateBookRequest(requestId, updates)
+}
+
+export async function markBorrowedBookReturned(borrowId: string) {
+  return db.returnBook(borrowId, {})
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated librarian control centre page backed by a reusable librarian service and updated dashboard UX
- extend the in-memory database model for books and loans while wiring real-time subscriptions into the client dashboard
- expose REST endpoints for librarian books, loans, requests, and overview data while aligning shared components with the new role

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68cc62ef73ec832788afa73b3ef390bd