### PR TITLE
Harden security and persistence for production deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,11 +85,15 @@ For cPanel with Node.js support.
 Set these in your cPanel Node.js app environment:
 
 \`\`\`env
-# Database (Optional - uses localStorage by default)
-DATABASE_URL=mysql://username:password@localhost:3306/vea_portal
-
-# JWT Secret (Required for Node.js)
+# JWT Secret (Required and must be at least 32 characters)
 JWT_SECRET=your-super-secret-jwt-key-here
+
+# Persistent data directory (must be writable)
+APP_DATA_DIR=/home/username/vea-data
+
+# CORS configuration for API calls
+CORS_ALLOWED_ORIGINS=https://portal2.victoryeducationalacademy.com.ng
+CORS_ALLOW_CREDENTIALS=false
 
 # Paystack Integration
 PAYSTACK_SECRET_KEY=sk_test_your_paystack_secret_key
@@ -135,12 +139,11 @@ NEXT_TELEMETRY_DISABLED=1
 
 ## 💾 Data Persistence
 
-### Current System (localStorage)
-- All data stored in browser localStorage
-- Each user's data persists across sessions
-- Teachers can enter real student data immediately
-- Report cards generate with actual entered information
-- Works offline after initial load
+### Current System (File-backed JSON store)
+- Server-side state (sessions, rate limits, seeded datasets) is stored as JSON in `APP_DATA_DIR`
+- Configure `APP_DATA_DIR` to point at a persistent, backed-up location on your hosting platform
+- Browser localStorage is only used for client-side caches; server APIs read/write from the shared JSON store
+- Works in single-instance Node.js deployments such as cPanel applications
 
 ### Future Database Integration
 - MySQL database support ready

--- a/README.md
+++ b/README.md
@@ -85,7 +85,19 @@ PAYSTACK_SECRET_KEY=sk_live_your_paystack_secret_key
 NEXT_PUBLIC_APP_URL=https://portal2.victoryeducationalacademy.com.ng
 
 # Authentication
-JWT_SECRET=your_jwt_secret_key
+# Must be at least 32 characters. Required in production.
+JWT_SECRET=your_jwt_secret_key_that_is_at_least_32_characters
+
+# API Security
+# Comma separated list of allowed origins for API requests.
+CORS_ALLOWED_ORIGINS=https://portal2.victoryeducationalacademy.com.ng,https://admin.victoryeducationalacademy.com.ng
+# Enable only if you expect cookie-based requests from the allowed origins.
+CORS_ALLOW_CREDENTIALS=false
+
+# Persistence
+# Directory where JSON state (rate limits, sessions, cached data) is stored.
+# Point this to a writable location on your server or mounted volume.
+APP_DATA_DIR=/home/username/vea-data
 
 # Application
 NODE_ENV=production

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,20 +2,12 @@
 // Purpose: Stable, accessible landing page without hydration warnings.
 // Fixes: Loading flicker, server/client markup mismatch, inconsistent spacing.
 // Notes:
-// - Marked as a Client Component because it uses useEffect/useState.
+// - Renders as a Server Component to avoid unnecessary client JavaScript.
 // - Uses the HSL token classes defined in app/globals.css.
 
-"use client";
-
-import { useEffect, useState } from "react";
 import Link from "next/link";
 
 export default function Page() {
-  // Avoids hydration mismatches by rendering only after mount.
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
-
   return (
     <section className="space-y-4">
       <header className="space-y-1">

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -30,6 +30,7 @@ jest.mock("next/router", () => ({
 process.env.PAYSTACK_SECRET_KEY = "sk_test_mock_key"
 process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000"
 process.env.NODE_ENV = "test"
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret-change-me-please-0123456789"
 
 // Global test utilities
 global.mockUser = {

--- a/lib/safe-storage.ts
+++ b/lib/safe-storage.ts
@@ -1,16 +1,54 @@
+import { readPersistentState, writePersistentState } from "./persistent-state"
+
 interface SafeStorage {
   getItem: (key: string) => string | null
   setItem: (key: string, value: string) => void
   removeItem: (key: string) => void
 }
 
+const SERVER_STORE_KEY = "app.serverStorage"
+
+type ServerStore = Record<string, string>
+
+let serverStoreCache: ServerStore | null = null
+
+function getServerStore() {
+  if (!serverStoreCache) {
+    serverStoreCache = readPersistentState<ServerStore>(SERVER_STORE_KEY, () => ({}))
+  }
+  return serverStoreCache
+}
+
+function persistServerStore() {
+  if (serverStoreCache) {
+    writePersistentState(SERVER_STORE_KEY, serverStoreCache)
+  }
+}
+
 const createSafeStorage = (): SafeStorage => {
   if (typeof window === "undefined") {
-    // Server-side: return no-op functions
+    // Server-side: persist using the shared JSON store
     return {
-      getItem: () => null,
-      setItem: () => {},
-      removeItem: () => {},
+      getItem: (key: string) => {
+        const store = getServerStore()
+        return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+      },
+      setItem: (key: string, value: string) => {
+        const store = getServerStore()
+        if (store[key] === value) {
+          return
+        }
+        store[key] = value
+        persistServerStore()
+      },
+      removeItem: (key: string) => {
+        const store = getServerStore()
+        if (!Object.prototype.hasOwnProperty.call(store, key)) {
+          return
+        }
+        delete store[key]
+        persistServerStore()
+      },
     }
   }
 

--- a/lib/session-store.ts
+++ b/lib/session-store.ts
@@ -1,0 +1,63 @@
+import { readPersistentState, resetPersistentState, writePersistentState } from "./persistent-state"
+
+const STORE_KEY = "auth.sessions"
+
+type SessionRecord = {
+  userId: string
+  expiresAt: number
+}
+
+type SessionStore = Record<string, SessionRecord>
+
+let cache: SessionStore | null = null
+
+function getStore() {
+  if (!cache) {
+    cache = readPersistentState<SessionStore>(STORE_KEY, () => ({}))
+  }
+  return cache
+}
+
+function persist() {
+  if (cache) {
+    writePersistentState(STORE_KEY, cache)
+  }
+}
+
+export function saveSession(token: string, record: SessionRecord) {
+  const store = getStore()
+  store[token] = record
+  persist()
+}
+
+export function getSessionRecord(token: string) {
+  const store = getStore()
+  return store[token] ?? null
+}
+
+export function deleteSession(token: string) {
+  const store = getStore()
+  if (store[token]) {
+    delete store[token]
+    persist()
+  }
+}
+
+export function sweepExpiredSessions(now = Date.now()) {
+  const store = getStore()
+  let dirty = false
+  for (const [token, record] of Object.entries(store)) {
+    if (record.expiresAt <= now) {
+      delete store[token]
+      dirty = true
+    }
+  }
+  if (dirty) {
+    persist()
+  }
+}
+
+export function resetSessionStore() {
+  cache = null
+  resetPersistentState(STORE_KEY)
+}


### PR DESCRIPTION
## Summary
- render the landing page as a server component to remove the client-only mounting guard
- require a stable JWT secret, persist auth sessions and shared state on disk, and reuse the new store for server-side safe storage
- add a configurable CORS allowlist and document the new environment requirements for deployment

## Testing
- pnpm lint *(fails: existing repo has numerous lint errors in component files unrelated to this change)*
- pnpm test
- pnpm type-check *(fails: existing TypeScript errors in shared components/tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cce46b2ec88327b803654f932e0b27