### PR TITLE
Fix Next.js build failures from server event handlers and dynamic APIs

### DIFF
--- a/app/api/admin/activity/route.ts
+++ b/app/api/admin/activity/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { listAdminActivities, type UserRole } from "@/lib/admin-service";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/admin-service";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { listPayments, type PaymentStatus } from "@/lib/payments-store"
 
 export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/super-admin/activity/route.ts
+++ b/app/api/super-admin/activity/route.ts
@@ -4,6 +4,7 @@ import { getRecentActivities } from "@/lib/super-admin-service";
 import type { Audience } from "@/lib/super-admin-service";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 const ALLOWED_ROLES: Audience[] = [
   "super-admin",

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,28 @@
 // app/not-found.tsx
-// Global 404 page for the App Router (server component by default).
-// Keeps styling consistent without importing client-only UI components.
+// Global 404 page for the App Router.
+// Marked as a Client Component so we can safely handle the "Go back" action
+// without triggering serialization errors during static rendering.
 
+"use client";
+
+import { useCallback } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function NotFound() {
+  const router = useRouter();
+
+  const handleGoBack = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    router.push("/");
+  }, [router]);
+
   return (
     <section className="mx-auto grid min-h-[60dvh] w-full max-w-2xl place-items-center p-6">
       <div className="w-full rounded-2xl border bg-card p-6 shadow-sm">
@@ -22,7 +40,7 @@ export default function NotFound() {
           </Link>
           <button
             type="button"
-            onClick={() => (typeof window !== "undefined" ? window.history.back() : null)}
+            onClick={handleGoBack}
             className="inline-flex h-10 items-center justify-center rounded-xl border border-transparent bg-[hsl(var(--muted))] px-4 text-sm font-medium text-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
           >
             Go Back


### PR DESCRIPTION
## Summary
- mark the global not-found page as a client component and provide a safe "go back" handler so the build no longer fails on server event handlers
- declare admin, payments, and super-admin activity API routes as `force-dynamic` so using `request.nextUrl`/`request.url` no longer triggers static generation errors

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdbe0a5fb88327937e3c13a2fe0285